### PR TITLE
Added key to force reconnect footer text specifier

### DIFF
--- a/PsiphonClientCommonLibrary/Resources/InAppSettings.bundle/ConnectionHelp.plist
+++ b/PsiphonClientCommonLibrary/Resources/InAppSettings.bundle/ConnectionHelp.plist
@@ -63,6 +63,8 @@
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
 		<dict>
+			<key>Key</key>
+			<string>forceReconnectFooter</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>FooterText</key>


### PR DESCRIPTION
- Required to identify and hide the specifier