### PR TITLE
Change plist default init to walk from root plist

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - InAppSettingsKit (2.9.4)
-  - PsiphonClientCommonLibrary (0.2.15):
+  - PsiphonClientCommonLibrary (0.2.18):
     - InAppSettingsKit
 
 DEPENDENCIES:
@@ -21,7 +21,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   InAppSettingsKit: 567ef538698cd6cf3afb9c5529b89a8936fdacb5
-  PsiphonClientCommonLibrary: 16eb8b65914bdbcb9782891b889d93934df46bf1
+  PsiphonClientCommonLibrary: 58c7a66b526aef97ee46d8ce038241a449a1a1e6
 
 PODFILE CHECKSUM: 16c02ac5a8b7439e7f6ba119ae1ed1746a844258
 

--- a/PsiphonClientCommonLibrary.podspec
+++ b/PsiphonClientCommonLibrary.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'PsiphonClientCommonLibrary'
-  s.version          = '0.2.17'
+  s.version          = '0.2.18'
   s.summary          = 'Psiphon iOS Shared Client Library.'
 
 # This description is used to generate tags and improve search results.

--- a/PsiphonClientCommonLibrary/Classes/PsiphonClientCommonLibraryHelpers.h
+++ b/PsiphonClientCommonLibrary/Classes/PsiphonClientCommonLibraryHelpers.h
@@ -24,7 +24,13 @@
 
 + (NSBundle * _Nonnull)commonLibraryBundle;
 + (UIImage * _Nullable)imageFromCommonLibraryNamed:(NSString* _Nonnull)imageName;
-+ (void)initializeDefaultsFor:(NSString* _Nonnull)plist;
+
+/*!
+ Starting from `rootPlist`, walk through all referenced plists initializing
+ defaults as needed.
+ */
++ (void)initializeDefaultsForPlistsFromRoot:(NSString* _Nonnull)rootPlist;
+
 + (NSString * _Nullable)getPsiphonBundledConfig;
 + (BOOL)unsupportedCharactersForFont:(NSString* _Nonnull)font withString:(NSString* _Nonnull)string;
 + (NSDictionary * _Nullable)jsonToDictionary:(NSString* _Nonnull)jsonString;

--- a/PsiphonClientCommonLibrary/Classes/PsiphonClientCommonLibraryHelpers.m
+++ b/PsiphonClientCommonLibrary/Classes/PsiphonClientCommonLibraryHelpers.m
@@ -25,83 +25,119 @@
 + (NSBundle*)commonLibraryBundle {
     NSBundle *frameworkBundle = [NSBundle bundleForClass:self.classForCoder];
     NSString *bundlePath = [frameworkBundle pathForResource:kPsiphonClientCommonLibraryBundleName ofType:@"bundle"];
-	NSBundle *bundle = [NSBundle bundleWithPath:bundlePath];
-	return bundle;
+    NSBundle *bundle = [NSBundle bundleWithPath:bundlePath];
+    return bundle;
 }
 
 // From http://blog.flaviocaetano.com/post/cocoapods-and-resource_bundles/
 + (UIImage*)imageFromCommonLibraryNamed:(NSString*)imageName {
-	return [UIImage imageNamed:imageName inBundle:[PsiphonClientCommonLibraryHelpers commonLibraryBundle] compatibleWithTraitCollection:nil];
+    return [UIImage imageNamed:imageName inBundle:[PsiphonClientCommonLibraryHelpers commonLibraryBundle] compatibleWithTraitCollection:nil];
 }
 
-+ (void)initializeDefaultsFor:(NSString*)plist {
-	NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+// See header for comment.
++ (void)initializeDefaultsForPlistsFromRoot:(NSString* _Nonnull)rootPlist {
+    // Set up some state, then call through to a recursive helper.
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    NSMutableArray *fileHistory = [[NSMutableArray alloc] init];
+    [PsiphonClientCommonLibraryHelpers initializeDefaultsForPlist:rootPlist
+                                                  withFileHistory:fileHistory
+                                                  andUserDefaults:userDefaults];
+    [userDefaults synchronize];
+}
 
-	// We'll look for the plist first in the main bundle...
-	NSString *plistPath = [[[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:@"InAppSettings.bundle"] stringByAppendingPathComponent:plist];
-	NSDictionary *settingsDictionary = [NSDictionary dictionaryWithContentsOfFile:plistPath];
+/*!
+ Recursive helper for initializeDefaultsForPlistsFromRoot.
+ */
++ (void)initializeDefaultsForPlist:(NSString* _Nullable)plistName
+                   withFileHistory:(NSMutableArray* _Nonnull)fileHistory
+                   andUserDefaults:(NSUserDefaults* _Nonnull)userDefaults {
+    if (!plistName) {
+        return;
+    }
 
-	// ...and then in the PsiphonClientCommonLibrary bundle.
-	if (settingsDictionary == nil) {
-		plistPath = [[[PsiphonClientCommonLibraryHelpers commonLibraryBundle] bundlePath] stringByAppendingPathComponent:plist];
-		settingsDictionary = [NSDictionary dictionaryWithContentsOfFile:plistPath];
-	}
+    if ([plistName hasSuffix:@".plist"]) {
+        NSLog(@"initializeDefaultsForPlist error: Do not include .plist extension: %@", plistName);
+        abort();
+    }
 
-	if (settingsDictionary == nil) {
-		NSLog(@"initializeDefaultsFor: Failed to find plist: %@", plist);
-		abort();
-	}
+    // Prevent cycles (infinite recursion) by keeping track of which plists we have
+    // already processed.
+    NSInteger fileIndex = [fileHistory indexOfObject:plistName];
+    if (fileIndex != NSNotFound){
+        return;
+    }
+    [fileHistory addObject:plistName];
 
-	for (NSDictionary *pref in settingsDictionary[@"PreferenceSpecifiers"]) {
-		NSString *key = pref[@"Key"];
-		if (key == nil)
-			continue;
+    // We'll look for the plist first in the main bundle...
+    NSString *plistPath = [[NSBundle mainBundle] pathForResource:plistName ofType:@"plist" inDirectory:@"InAppSettings.bundle"];
+    NSDictionary *settingsDictionary = [NSDictionary dictionaryWithContentsOfFile:plistPath];
 
-		if ([userDefaults objectForKey:key] == NULL) {
-			NSObject *val = pref[@"DefaultValue"];
-			if (val == nil)
-				continue;
+    // ...and then in the PsiphonClientCommonLibrary bundle.
+    if (settingsDictionary == nil) {
+        plistPath = [[PsiphonClientCommonLibraryHelpers commonLibraryBundle] pathForResource:plistName ofType:@"plist"];
+        settingsDictionary = [NSDictionary dictionaryWithContentsOfFile:plistPath];
+    }
 
-			[userDefaults setObject:val forKey:key];
+    if (!settingsDictionary) {
+        NSLog(@"initializeDefaultsForPlist error: Failed to find plist: %@", plistName);
+        abort();
+    }
+
+    for (NSDictionary *pref in settingsDictionary[@"PreferenceSpecifiers"]) {
+        NSString *key = pref[@"Key"];
+        if (key != nil && [userDefaults objectForKey:key] == NULL) {
+            NSObject *val = pref[@"DefaultValue"];
+            if (val != nil)
+            {
+                [userDefaults setObject:val forKey:key];
 #ifdef TRACE
-			NSLog(@"initialized default preference for %@ to %@", key, val);
+                NSLog(@"initialized default preference for %@ to %@", key, val);
 #endif
-		}
-	}
-	[userDefaults synchronize];
+            }
+        }
+
+        NSString* type = pref[@"Type"];
+        if (([type isEqualToString:@"PSChildPaneSpecifier"] || [type isEqualToString:@"IASKCustomViewSpecifier"]) &&
+            pref[@"File"]) {
+            // Make a recursive call.
+            [PsiphonClientCommonLibraryHelpers initializeDefaultsForPlist:pref[@"File"]
+                                                          withFileHistory:fileHistory
+                                                          andUserDefaults:userDefaults];
+        }
+    }
 }
 
 + (NSString * _Nullable)getPsiphonBundledConfig {
-	NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
 
-	NSString *bundledConfigPath = [[[NSBundle mainBundle] resourcePath]
-								   stringByAppendingPathComponent:@"psiphon_config"];
+    NSString *bundledConfigPath = [[[NSBundle mainBundle] resourcePath]
+                                   stringByAppendingPathComponent:@"psiphon_config"];
 
-	if (![fileManager fileExistsAtPath:bundledConfigPath]) {
-		NSLog(@"Config file not found for feedback upload.");
-		return @"";
-	}
+    if (![fileManager fileExistsAtPath:bundledConfigPath]) {
+        NSLog(@"Config file not found for feedback upload.");
+        return @"";
+    }
 
-	// Read in psiphon_config JSON
-	NSData *jsonData = [fileManager contentsAtPath:bundledConfigPath];
-	NSError *err = nil;
-	NSDictionary *readOnly = [NSJSONSerialization JSONObjectWithData:jsonData options:kNilOptions error:&err];
+    // Read in psiphon_config JSON
+    NSData *jsonData = [fileManager contentsAtPath:bundledConfigPath];
+    NSError *err = nil;
+    NSDictionary *readOnly = [NSJSONSerialization JSONObjectWithData:jsonData options:kNilOptions error:&err];
 
-	if (err) {
-		NSLog(@"Failed to parse config JSON for feedback upload: %@", err.description);
-		return @"";
-	}
+    if (err) {
+        NSLog(@"Failed to parse config JSON for feedback upload: %@", err.description);
+        return @"";
+    }
 
-	NSMutableDictionary *mutableConfigCopy = [readOnly mutableCopy];
-	jsonData  = [NSJSONSerialization dataWithJSONObject:mutableConfigCopy
-												options:0 error:&err];
+    NSMutableDictionary *mutableConfigCopy = [readOnly mutableCopy];
+    jsonData  = [NSJSONSerialization dataWithJSONObject:mutableConfigCopy
+                                                options:0 error:&err];
 
-	if (err) {
-		NSLog(@"Failed to create JSON data from config object for feedback upload: %@", err.description);
-		abort();
-	}
+    if (err) {
+        NSLog(@"Failed to create JSON data from config object for feedback upload: %@", err.description);
+        abort();
+    }
 
-	return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 }
 
 + (BOOL)unsupportedCharactersForFont:(NSString* _Nonnull)font withString:(NSString* _Nonnull)string {


### PR DESCRIPTION
This avoid potential (and actual) bugs where someone adds a plist file and forgets to put it into `AppDelegate`'s `initializeDefaults` function.

It also avoids having to initialize `*~iphone.plist` files and `*~ipad.plist` files when only one platform will be actually used by the app. (Potentially causing a bug, if the default is different between the platforms.)